### PR TITLE
Adds letheanVPN/wails-build-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
           build-platform: linux/amd64
           deno-build: "npm run server:build:linux"
           deno-working-directory: "server"
+          wails-build-webview2: "embed"
       - name: 'Tar files'
         run: cd build/bin/ && tar -cvf ../../linux-lethean-desktop.tar .
       # uploads the job file, makes no release
@@ -67,6 +68,7 @@ jobs:
           build-platform: darwin/universal
           deno-build: "npm run server:build:macos-intel"
           deno-working-directory: "server"
+          wails-build-webview2: "embed"
       - name: Import Code-Signing Certificates for macOS
         if: startsWith(github.ref, 'refs/tags/')
         uses: Apple-Actions/import-codesign-certs@v1
@@ -119,9 +121,10 @@ jobs:
           submodules: recursive
       - uses: letheanVPN/wails-build-action@main
         with:
-          platform: windows/amd64
+          build-platform: windows/amd64
           deno-build: "npm run server:build:windows"
           deno-working-directory: "server"
+          wails-build-webview2: "embed"
       # uploads the job file, makes no release
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,33 +28,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      # Install GoLang
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-      - uses: actions/setup-node@v2
+      # Install Wails build deps
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
         with:
           node-version: 16.x
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.20.1
-      # Set up GoLang cache
-      - name: Go Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      # Install Wails build deps
-      - run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.0-dev
-      - run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
       - run: cd server && npm run server:build:linux
-      - name: Build
-        run: wails build --platform linux/amd64 -webview2 embed
+      - run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.0-dev
+      - uses: letheanVPN/wails-build-action@main
+        with:
+          platform: linux/amd64
       - run: chmod +x build/bin/lethean
       - name: 'Tar files'
         run: cd build/bin/ && tar -cvf ../../linux-lethean-desktop.tar .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,35 +71,20 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      # Install GoLang
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.20.1
-      # Set up GoLang cache
-      - name: Go Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - run: | 
-            go install github.com/wailsapp/wails/v2/cmd/wails@latest
             brew install mitchellh/gon/gon
             cd server && npm run server:build:macos-intel
-      - name: Build
-        run: wails build --platform darwin/universal -webview2 embed
+      - uses: letheanVPN/wails-build-action@main
+        with:
+          platform: darwin/universal
       - name: chmod +x exe
-        run: chmod +x build/bin/lethean.app/Contents/MacOS/lethean
+        run: chmod +x build/bin/*/Contents/MacOS/*
       - name: Import Code-Signing Certificates for macOS
         if: startsWith(github.ref, 'refs/tags/')
         uses: Apple-Actions/import-codesign-certs@v1
@@ -150,31 +135,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      # Install GoLang
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.20.1
-      # Set up GoLang cache
-      - name: Go Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            %LocalAppData%\go-build
-            ~\go\pkg\mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - run: cd server && npm run server:build:windows
-      - run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
-      - name: Build
-        run: wails build --platform windows/amd64 -webview2 embed -nsis
-
+      - uses: letheanVPN/wails-build-action@main
+        with:
+          platform: windows/amd64
       # uploads the job file, makes no release
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dev'
       - 'v*'
     tags:
       - 'v*'
@@ -16,6 +17,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'dev'
       - 'v*'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: letheanVPN/wails-build-action@main
+      - uses: letheanVPN/wails-build-action@v1
         with:
           build-platform: linux/amd64
           deno-build: "npm run server:build:linux"
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: letheanVPN/wails-build-action@main
+      - uses: letheanVPN/wails-build-action@v1
         with:
           build-platform: darwin/universal
           deno-build: "npm run server:build:macos-intel"
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: letheanVPN/wails-build-action@main
+      - uses: letheanVPN/wails-build-action@v1
         with:
           build-platform: windows/amd64
           deno-build: "npm run server:build:windows"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.20.1
       - run: cd server && npm run server:build:linux
       - run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.0-dev
       - uses: letheanVPN/wails-build-action@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,20 +30,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      # Install Wails build deps
-      - name: Setup NodeJS
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.20.1
-      - run: cd server && npm run server:build:linux
-      - run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.0-dev
       - uses: letheanVPN/wails-build-action@main
         with:
-          platform: linux/amd64
-      - run: chmod +x build/bin/lethean
+          build-platform: linux/amd64
+          deno-build: "cd server && npm run server:build:linux"
       - name: 'Tar files'
         run: cd build/bin/ && tar -cvf ../../linux-lethean-desktop.tar .
       # uploads the job file, makes no release
@@ -71,20 +61,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.20.1
-      - run: | 
-            brew install mitchellh/gon/gon
-            cd server && npm run server:build:macos-intel
       - uses: letheanVPN/wails-build-action@main
         with:
-          platform: darwin/universal
-      - name: chmod +x exe
-        run: chmod +x build/bin/*/Contents/MacOS/*
+          build-platform: darwin/universal
+          deno-build: "cd server && npm run server:build:macos-intel && cd .."
       - name: Import Code-Signing Certificates for macOS
         if: startsWith(github.ref, 'refs/tags/')
         uses: Apple-Actions/import-codesign-certs@v1
@@ -135,16 +115,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.20.1
-      - run: cd server && npm run server:build:windows
       - uses: letheanVPN/wails-build-action@main
         with:
           platform: windows/amd64
+          deno-build: "cd server && npm run server:build:windows && cd .."
       # uploads the job file, makes no release
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,8 @@ jobs:
       - uses: letheanVPN/wails-build-action@main
         with:
           build-platform: linux/amd64
-          deno-build: "cd server && npm run server:build:linux"
+          deno-build: "npm run server:build:linux"
+          deno-working-directory: "server"
       - name: 'Tar files'
         run: cd build/bin/ && tar -cvf ../../linux-lethean-desktop.tar .
       # uploads the job file, makes no release
@@ -64,7 +65,8 @@ jobs:
       - uses: letheanVPN/wails-build-action@main
         with:
           build-platform: darwin/universal
-          deno-build: "cd server && npm run server:build:macos-intel && cd .."
+          deno-build: "npm run server:build:macos-intel"
+          deno-working-directory: "server"
       - name: Import Code-Signing Certificates for macOS
         if: startsWith(github.ref, 'refs/tags/')
         uses: Apple-Actions/import-codesign-certs@v1
@@ -118,7 +120,8 @@ jobs:
       - uses: letheanVPN/wails-build-action@main
         with:
           platform: windows/amd64
-          deno-build: "cd server && npm run server:build:windows && cd .."
+          deno-build: "npm run server:build:windows"
+          deno-working-directory: "server"
       # uploads the job file, makes no release
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
moves our build code into a sharable gh action for @wailsapp 

https://github.com/marketplace/actions/wails-build-action

```yaml
- uses: letheanVPN/wails-build-action@v1
  with:
    build-platform: linux/amd64
```